### PR TITLE
Remove all mailkick subscriptions when deleting a subscriber

### DIFF
--- a/app/controllers/videos/unsubscribes_controller.rb
+++ b/app/controllers/videos/unsubscribes_controller.rb
@@ -4,20 +4,20 @@ class Videos::UnsubscribesController < ApplicationController
   def new; end
 
   def destroy
-    @subscriber = Subscriber.find_by(email: subscriber_params[:email])
-    if @subscriber
-      @subscriber.destroy
+    case destroy_subscriber.call
+    when Dry::Monads::Success
       flash[:notice] = "You have been unsubscribed from the mailing list."
       redirect_to page_path("videos")
     else
-      flash[:error] = "Cannot find your email address!"
+      flash[:error] =
+        "Cannot find your email address or cannot remove your subscription! Please contact support@shortruby.com to remove it"
       redirect_to new_videos_unsubscribe_path
     end
   end
 
   private
 
-    def subscriber_params
-      params.require(:subscriber).permit(:email)
-    end
+    def email = params.require(:subscriber).permit(:email).fetch(:email)
+
+    def destroy_subscriber = Subscribers::Delete.new(email:)
 end

--- a/app/models/subscribers/delete.rb
+++ b/app/models/subscribers/delete.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Subscribers
+  class Delete
+    include Dry::Monads[:result]
+
+    def initialize(email:)
+      @email = email
+      @subscriber = Subscriber.find_by(email:)
+    end
+
+    def call
+      return Failure(email) unless subscriber
+
+      Subscriber.transaction do
+        subscriber.mailkick_subscriptions.destroy_all
+        subscriber.destroy
+      end
+
+      Success(email)
+    end
+
+    private
+
+      attr_reader :email, :subscriber
+  end
+end

--- a/app/views/videos/unsubscribes/destroy.turbo_stream.erb
+++ b/app/views/videos/unsubscribes/destroy.turbo_stream.erb
@@ -1,1 +1,1 @@
-<%= turbo_stream.prepend "flash", partial: "layouts/flash" %>
+<%= turbo_stream.prepend "notification", partial: "layouts/flash" %>

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -3,5 +3,5 @@
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
+  driven_by :selenium, using: :chrome, screen_size: [1400, 1400]
 end

--- a/test/models/subscribers/delete_test.rb
+++ b/test/models/subscribers/delete_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Subscribers::DeleteTest < ActiveSupport::TestCase
+  test "successfully deletes a subscriber" do
+    existing_subscriber = subscribers(:already_subscribed)
+    service = Subscribers::Delete.new(email: existing_subscriber.email)
+
+    result = service.call
+
+    assert_predicate result, :success?
+    assert_nil Subscriber.find_by(email: existing_subscriber.email)
+    assert_equal 0, Mailkick::Subscription.where(subscriber: existing_subscriber).count
+  end
+
+  test "fails when email is not present" do
+    service = Subscribers::Delete.new(email: "not_exist@example.com")
+
+    result = service.call
+
+    assert_predicate result, :failure?
+    refute_nil Subscriber.find_by(email: "test@example.com")
+  end
+end

--- a/test/system/videos/unsubscribe_system_test.rb
+++ b/test/system/videos/unsubscribe_system_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class Videos::UnsubscribesSystemTest < ApplicationSystemTestCase
+  setup do
+    @subscriber = subscribers(:already_subscribed)
+  end
+
+  test "successfully unsubscribes a user" do
+    visit new_videos_unsubscribe_path
+
+    fill_in "subscriber_email", with: @subscriber.email
+    click_button "Unsubscribe"
+
+    assert_current_path page_path("videos")
+    assert_text "You have been unsubscribed from the mailing list."
+
+    assert_nil Subscriber.find_by(email: @subscriber.email)
+  end
+
+  test "unsuccessfully unsubscribes a user with email not in system" do
+    visit new_videos_unsubscribe_path
+
+    fill_in "subscriber_email", with: "not_exist@example.com"
+    click_button "Unsubscribe"
+
+    assert_current_path new_videos_unsubscribe_path
+    assert_text "Cannot find your email address or cannot remove your subscription! Please contact support@shortruby.com to remove it"
+  end
+end


### PR DESCRIPTION
This commit also moves the logic from the controller to a model to allow further extensions when needed in the future.